### PR TITLE
Add export preparation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build output
 dist/
 build/
+export/
 
 # Vite cache
 .vite/

--- a/README.md
+++ b/README.md
@@ -240,6 +240,52 @@ The `MonitoringDashboard` component manages its own styling and theming (light/d
     }
     ```
 
+### Exporting to Another Project
+
+You can either copy the source files directly or package the tool as a small npm
+dependency.
+
+#### 1. Manual copy
+
+Run `npm run prepare-export`. This command collects all the relevant source
+files (`components/`, `services/`, `hooks/`, `utils/`, `constants.ts`, and
+`types.ts`) into a new `export/` folder.
+
+Copy that folder into your other project's source directory:
+
+```bash
+cp -r export/ your-other-project/src/monitoring-tool
+```
+
+Import the dashboard component using a relative path:
+
+```tsx
+import { MonitoringDashboard } from './monitoring-tool/components/MonitoringDashboard';
+```
+
+#### 2. Package as an npm dependency
+
+1.  Run `npm run build` to generate a `dist/` folder with compiled JavaScript
+    files.
+2.  Create a tarball with `npm pack`. The command outputs a file such as
+    `in-app-monitoring-tool-0.0.0.tgz` in the project root.
+3.  In your other project, install the tarball:
+
+    ```bash
+    npm install ../path/to/in-app-monitoring-tool-0.0.0.tgz
+    ```
+
+    (You can also publish the tarball to a private registry and install from
+    there.)
+4.  Import the dashboard component from the package:
+
+    ```tsx
+    import { MonitoringDashboard } from 'in-app-monitoring-tool';
+    ```
+
+Both approaches keep the monitoring code isolated so you can update it
+independently of your host applications.
+
 ## Showcase / How it Works
 
 The tool is self-contained. The `MonitoringDashboard` component is the single UI entry point you need to render. The `MonitoringService` automatically:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prepare-export": "node scripts/package.mjs"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -1,0 +1,25 @@
+import { cp, rm, mkdir } from 'fs/promises';
+import path from 'path';
+
+const exportDir = path.resolve('export');
+
+await rm(exportDir, { recursive: true, force: true });
+await mkdir(exportDir, { recursive: true });
+
+const entries = [
+  'components',
+  'services',
+  'hooks',
+  'utils',
+  'constants.ts',
+  'types.ts'
+];
+
+for (const entry of entries) {
+  const src = path.resolve(entry);
+  const dest = path.join(exportDir, entry);
+  await cp(src, dest, { recursive: true });
+}
+
+console.log(`Export folder prepared at ${exportDir}`);
+


### PR DESCRIPTION
## Summary
- add a node script that collects source files into an `export/` folder
- document how to manually copy the prepared folder or package the tool as a tarball
- ignore the generated `export/` folder
- expose the script via `npm run prepare-export`

## Testing
- `npm run build` *(fails: vite not found)*
- `node --loader ts-node/esm run-tests.ts` *(fails: ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_e_684027761a6c832a8b825e57c8081d68