### PR TITLE
Move test panel to separate page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,10 @@
 
 import React, { useEffect } from 'react';
 import { MonitoringDashboard } from './components/MonitoringDashboard';
-import TestRequestPanel from './components/TestRequestPanel';
+import TestRequestsPage from './components/TestRequestsPage';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { store } from './store';
 import { MonitoringService } from './services/MonitoringService'; // Ensures service is initialized on app load
 import { getItem } from './utils/localStorageHelper';
 import { THEME_STORAGE_KEY, MONITORING_STATUS_KEY } from './constants';
@@ -25,12 +28,20 @@ const App: React.FC = () => {
   }, []);
 
   return (
-    // The main div no longer needs dark mode specific classes here,
-    // as body tag in index.html handles the base background colors for light/dark.
-    <div style={{ minHeight: '100vh' }}>
-      <TestRequestPanel />
-      <MonitoringDashboard />
-    </div>
+    <Provider store={store}>
+      <BrowserRouter>
+        <div style={{ minHeight: '100vh' }}>
+          <nav style={{ padding: '0.5rem' }}>
+            <Link to="/">Dashboard</Link> |{' '}
+            <Link to="/test">Test Requests</Link>
+          </nav>
+          <Routes>
+            <Route path="/" element={<MonitoringDashboard />} />
+            <Route path="/test" element={<TestRequestsPage />} />
+          </Routes>
+        </div>
+      </BrowserRouter>
+    </Provider>
   );
 };
 

--- a/components/TestRequestPanel.test.tsx
+++ b/components/TestRequestPanel.test.tsx
@@ -35,6 +35,7 @@ describe('TestRequestPanel', () => {
   it('should throw an error when Trigger Error button clicked', () => {
     const panel = TestRequestPanel() as React.ReactElement;
     const buttons = React.Children.toArray((panel.props as {children: React.ReactNode}).children) as React.ReactElement[];
-    expect(() => buttons[4].props.onClick()).toThrow('Test error from TestRequestPanel');
+    const errorButton = buttons[buttons.length - 1];
+    expect(() => errorButton.props.onClick()).toThrow('Test error from TestRequestPanel');
   });
 });

--- a/components/TestRequestPanel.tsx
+++ b/components/TestRequestPanel.tsx
@@ -1,6 +1,17 @@
 import React from 'react';
+import axios from 'axios';
+import { useDispatch } from 'react-redux';
+import type { AppDispatch } from '../store';
+import {
+  fetchPostThunk,
+  postPostThunk,
+  axiosGetThunk,
+  axiosPostThunk,
+} from '../store';
 
 const TestRequestPanel: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+
   const sendRequest = async (method: string) => {
     const baseUrl = 'https://jsonplaceholder.typicode.com/posts';
     const url = method === 'GET' ? `${baseUrl}/1` : baseUrl;
@@ -15,6 +26,32 @@ const TestRequestPanel: React.FC = () => {
     }
   };
 
+  const sendAxiosRequest = async (method: 'GET' | 'POST') => {
+    const baseUrl = 'https://jsonplaceholder.typicode.com/posts';
+    const url = method === 'GET' ? `${baseUrl}/1` : baseUrl;
+    if (method === 'GET') {
+      await axios.get(url);
+    } else {
+      await axios.post(url, { title: 'foo', body: 'bar', userId: 1 });
+    }
+  };
+
+  const sendThunkRequest = async (method: 'GET' | 'POST') => {
+    if (method === 'GET') {
+      await dispatch(fetchPostThunk());
+    } else {
+      await dispatch(postPostThunk());
+    }
+  };
+
+  const sendAxiosThunkRequest = async (method: 'GET' | 'POST') => {
+    if (method === 'GET') {
+      await dispatch(axiosGetThunk());
+    } else {
+      await dispatch(axiosPostThunk());
+    }
+  };
+
   const triggerError = () => {
     throw new Error('Test error from TestRequestPanel');
   };
@@ -23,6 +60,12 @@ const TestRequestPanel: React.FC = () => {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '1rem' }}>
       <button onClick={() => sendRequest('GET')}>Send GET Request</button>
       <button onClick={() => sendRequest('POST')}>Send POST Request</button>
+      <button onClick={() => sendAxiosRequest('GET')}>Axios GET</button>
+      <button onClick={() => sendAxiosRequest('POST')}>Axios POST</button>
+      <button onClick={() => sendThunkRequest('GET')}>Thunk GET</button>
+      <button onClick={() => sendThunkRequest('POST')}>Thunk POST</button>
+      <button onClick={() => sendAxiosThunkRequest('GET')}>Axios Thunk GET</button>
+      <button onClick={() => sendAxiosThunkRequest('POST')}>Axios Thunk POST</button>
       <button onClick={() => sendRequest('PUT')}>Send PUT Request</button>
       <button onClick={() => sendRequest('DELETE')}>Send DELETE Request</button>
       <button onClick={triggerError}>Trigger Error</button>

--- a/components/TestRequestsPage.tsx
+++ b/components/TestRequestsPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import TestRequestPanel from './TestRequestPanel';
+import { Link } from 'react-router-dom';
+
+const TestRequestsPage: React.FC = () => {
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Test Requests</h2>
+      <TestRequestPanel />
+      <Link to="/">Back to Dashboard</Link>
+    </div>
+  );
+};
+
+export default TestRequestsPage;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "axios": "^1.6.7",
+    "react-router-dom": "^6.22.3",
+    "@reduxjs/toolkit": "^2.2.3",
+    "react-redux": "^9.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,0 +1,67 @@
+import { configureStore, createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+interface RequestState {
+  lastStatus: number | null;
+}
+
+const initialState: RequestState = {
+  lastStatus: null,
+};
+
+export const fetchPostThunk = createAsyncThunk('requests/fetchPost', async () => {
+  const response = await fetch('https://jsonplaceholder.typicode.com/posts/1');
+  return response.status;
+});
+
+export const postPostThunk = createAsyncThunk('requests/postPost', async () => {
+  const response = await fetch('https://jsonplaceholder.typicode.com/posts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'foo', body: 'bar', userId: 1 }),
+  });
+  return response.status;
+});
+
+export const axiosGetThunk = createAsyncThunk('requests/axiosGet', async () => {
+  const response = await axios.get('https://jsonplaceholder.typicode.com/posts/1');
+  return response.status;
+});
+
+export const axiosPostThunk = createAsyncThunk('requests/axiosPost', async () => {
+  const response = await axios.post('https://jsonplaceholder.typicode.com/posts', {
+    title: 'foo',
+    body: 'bar',
+    userId: 1,
+  });
+  return response.status;
+});
+
+const requestSlice = createSlice({
+  name: 'requests',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchPostThunk.fulfilled, (state, action) => {
+        state.lastStatus = action.payload;
+      })
+      .addCase(postPostThunk.fulfilled, (state, action) => {
+        state.lastStatus = action.payload;
+      })
+      .addCase(axiosGetThunk.fulfilled, (state, action) => {
+        state.lastStatus = action.payload;
+      })
+      .addCase(axiosPostThunk.fulfilled, (state, action) => {
+        state.lastStatus = action.payload;
+      });
+  },
+});
+
+export const store = configureStore({
+  reducer: {
+    requests: requestSlice.reducer,
+  },
+});
+
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Summary
- add request-related dependencies
- add Redux store with async thunks
- extend TestRequestPanel with axios and thunk actions
- create TestRequestsPage and route with React Router
- update tests for new button order

## Testing
- `tsc --outDir /tmp/tests run-tests.ts` *(fails: Property 'assign' does not exist on type 'ObjectConstructor')*

------
https://chatgpt.com/codex/tasks/task_e_6840367b68a0832a8a6994b4f70954ec