### PR TITLE
Wrap axios request with error handling

### DIFF
--- a/components/TestRequestPanel.tsx
+++ b/components/TestRequestPanel.tsx
@@ -29,10 +29,14 @@ const TestRequestPanel: React.FC = () => {
   const sendAxiosRequest = async (method: 'GET' | 'POST') => {
     const baseUrl = 'https://jsonplaceholder.typicode.com/posts';
     const url = method === 'GET' ? `${baseUrl}/1` : baseUrl;
-    if (method === 'GET') {
-      await axios.get(url);
-    } else {
-      await axios.post(url, { title: 'foo', body: 'bar', userId: 1 });
+    try {
+      if (method === 'GET') {
+        await axios.get(url);
+      } else {
+        await axios.post(url, { title: 'foo', body: 'bar', userId: 1 });
+      }
+    } catch (err: any) {
+      console.warn('Axios request failed', err);
     }
   };
 


### PR DESCRIPTION
## Summary
- add try/catch to axios request example

## Testing
- `node run-tests.ts` *(fails: Unknown file extension for run-tests.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68403a1cef4c832ab4674c13bd2ad982